### PR TITLE
chore(composer): enable auto register for symfony bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "api-scout/api-scout",
     "description": "A library with a few tools, to auto document your api",
-    "type": "library",
-    "license": "proprietary",
+    "type": "symfony-bundle",
+    "license": "MIT",
     "authors": [
         {
             "name": "Marvin Courcier",


### PR DESCRIPTION
regarding this requirement https://symfony.com/doc/current/bundles/best_practices.html#installation the type should be "symfony-bundle" to auto register it in the Bundle.php :D

suggestion: check this part about the naming https://symfony.com/doc/current/bundles/best_practices.html#composer-metadata it can be interesting

